### PR TITLE
Add callback with ordering change from PartoWithSelection

### DIFF
--- a/src/components/PartoWithSelection.js
+++ b/src/components/PartoWithSelection.js
@@ -9,7 +9,8 @@ function withSelection(Parto) {
   class WithSelection extends Component {
     static propTypes = {
       parto: PropTypes.array.isRequired,
-      itemList: PropTypes.array.isRequired
+      itemList: PropTypes.array.isRequired,
+      updateOrdering: PropTypes.func
     }
 
     constructor(props) {
@@ -18,25 +19,31 @@ function withSelection(Parto) {
       this.unorderedSelected = this.unorderedSelected.bind(this);
       this.orderedSelected = this.orderedSelected.bind(this);
       this.itemReorder = this.itemReorder.bind(this);
+      this.orderingCallback = this.props.updateOrdering || (() => {});
       this.state = {
         ordering: PartialOrder.encompassItems(props.itemList, ordering),
       };
     }
 
+    updateOrdering(updatedOrdering) {
+      this.setState({ ordering: updatedOrdering });
+      this.orderingCallback(updatedOrdering);
+    }
+
     unorderedSelected(key) {
       const updatedOrdering = PartialOrder.raiseItem(this.state.ordering, key);
-      this.setState({ ordering: updatedOrdering });
+      this.updateOrdering(updatedOrdering);
     }
 
     orderedSelected(key) {
       const updatedOrdering = PartialOrder.lowerItem(this.state.ordering, key);
-      this.setState({ ordering: updatedOrdering });
+      this.updateOrdering(updatedOrdering);
     }
 
     itemReorder(subject, target, before) {
       const updatedOrdering = PartialOrder.moveItem(this.state.ordering,
         subject, target, before);
-      this.setState({ ordering: updatedOrdering });
+      this.updateOrdering(updatedOrdering);
     }
 
     render() {

--- a/src/components/tests/SelectInOrder.test.js
+++ b/src/components/tests/SelectInOrder.test.js
@@ -2,11 +2,15 @@ import React from 'react';
 import { mount } from 'enzyme';
 import ListItems from '../../ListItems';
 import ListItemsFixtures from '../../fixtures/ListItemsFixtures';
-import PartoWithSelection from '../SelectInOrder';
+import PartoWithSelection from '../PartoWithSelection';
 
 describe('SelectInOrder', () => {
   const itemList = ListItemsFixtures.salad;
   const initialOrder = ['T','L',['M','P'],'A'];
+  let currentOrdering = initialOrder;
+  let updateOrderingCallback = jest.fn((ordering) => {
+      currentOrdering = ordering;
+    });
   let wrapper;
 
   beforeEach(() => {
@@ -14,7 +18,18 @@ describe('SelectInOrder', () => {
       <PartoWithSelection
         itemList={ itemList }
         parto={ initialOrder }
+        updateOrdering={ updateOrderingCallback }
       />
+    );
+  });
+
+  it ('sends a callback when the ordering changes', () => {
+    const item = ListItems.itemFor(itemList, 'R');
+    const itemWrapper = wrapper.find({ itemKey: item.key })
+    itemWrapper.simulate("click");
+    expect(updateOrderingCallback.mock.calls.length).toBe(1);
+    expect(currentOrdering).toEqual(
+      [ 'T', 'L', [ 'M', 'P' ], 'A', 'R', [ 'Z', 'C' ] ]
     );
   });
 


### PR DESCRIPTION
PartoWithSelection now takes a new property, updateOrdering, which, if provided, the component calls whenever the ordering changes. The component sends the new ordering as the sole parameter of the callback, which is an array in the Parto format.

Closes #7 