### PR TITLE
Correct dangling empty group bug

### DIFF
--- a/src/PartialOrder.js
+++ b/src/PartialOrder.js
@@ -28,9 +28,11 @@ const PartialOrder = {
   // Returns a new order with groups containing only one item replaced with
   //   the item
   flattenSoloGroups: (order) => {
-    return order.map((key) => {
+    const flat = order.map((key) => {
       if (Array.isArray(key)) {
-        if (key.length == 1) {
+        if (key.length == 0) {
+          return null;
+        } else if (key.length == 1) {
           return key[0];
         } else {
           return key;
@@ -39,6 +41,7 @@ const PartialOrder = {
         return key;
       }
     });
+    return flat.filter(key => key != null);
   },
 
   // Returns a new order arranged according to the given order, with
@@ -50,7 +53,7 @@ const PartialOrder = {
     const rest = keys.filter((key) => {
       return !included.includes(key);
     });
-    return PartialOrder.flattenSoloGroups(cleanOrder).concat([rest]);
+    return PartialOrder.flattenSoloGroups(cleanOrder.concat([rest]));
   },
 
   // Return a new group with item and given index removed

--- a/src/tests/PartialOrder/PartialOrderEncompass.test.js
+++ b/src/tests/PartialOrder/PartialOrderEncompass.test.js
@@ -32,4 +32,13 @@ describe("PartialOrder encompassItems", () => {
     expect(Array.isArray(order[2])).toBe(false);
     expect(order[2]).toBe(goodKey);
   });
+
+  it('correctly handles all items in one group', () => {
+    const keys = ListItems.keys(items);
+    const parto = new Array(keys);
+    const order = PartialOrder.encompassItems(items, parto);
+    expect(order.length).toBe(1);
+    expect(Array.isArray(order[0])).toBe(true);
+    expect(order).toStrictEqual(parto);
+  });
 });


### PR DESCRIPTION
The `encompassItems` function in `PartialOrder` appended an empty group if all items were already represtented by the `parto` expression. This adds a test and fix to clean that up.